### PR TITLE
Values from "instance_from" can be of a type other than string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The plugin is used in the [snap framework] (http://github.com/intelsdi-x/snap).
 ### System Requirements
 
 - Linux system
-- Access to database (currently following sql drivers are supported: **MySQL**, **PostgreSQL**)
+- Access to database (currently the following SQL Drivers are supported: **MySQL**, **PostgreSQL**)
 
 ### Installation
 
@@ -50,9 +50,9 @@ This builds the plugin in `/build/rootfs/`
 
 * Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
 
-* Create configuration file (called as a setfile) in which will be defined databases, queries and rules how interpret the results (see examplary in [examples/configs/setfiles](https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/master/examples/configs/setfiles))
+* Create configuration file (called as a setfile) in which will be defined databases, queries and rules how interpret the results, see exemplary in [examples/configs/setfiles](https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/master/examples/configs/setfiles)
 
-* Set up field `setfile` in Global Config as a path to dbi plugin configuration file. Sample Global Config is available in [examples/configs/snap-config-sample.json] (https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/master/examples/configs/snap-config-sample.json)
+* Set up field `setfile` in Global Config as a path to dbi plugin configuration file, see exemplary Snap Global Config: in [examples/configs/snap-config-sample.json] (https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/master/examples/configs/snap-config-sample.json)
  
 Notice that this plugin is a generic plugin, i.e. it cannot work without configuration, because there is no reasonable default behavior.
 
@@ -100,7 +100,7 @@ By default metrics are gathered once per second.
 
 Example of running snap dbi collector of and writing results to file.
 
-Create configuration file for dbi plugin (example from [examples/configs/setfiles/dbi_openstack.json](https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/dbi_plugin/examples/configs/setfiles/dbi_openstack.json)
+Create configuration file for dbi plugin (example from [examples/configs/setfiles/dbi_openstack.json](https://github.com/intelsdi-x/snap-plugin-collector-dbi/blob/dbi_plugin/examples/configs/setfiles/dbi_openstack.json))
 ```json
 {
     "databases": [

--- a/dbi/executor/executor.go
+++ b/dbi/executor/executor.go
@@ -18,6 +18,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // Execution is an interface for mocking purposes of sql functions like open(), ping(), exec(), close() etc.
@@ -73,7 +74,7 @@ func (se *SQLExecutor) Query(name, statement string) (map[string][]interface{}, 
 	defer rows.Close()
 
 	if err != nil {
-		return nil, fmt.Errorf("Cannot execute query `%+v`, err=%+v\n", statement, err)
+		return nil, fmt.Errorf("Cannot execute query `%+v`, err=%+v", statement, err)
 	}
 
 	// get query output (rows) and parse it to map
@@ -103,7 +104,8 @@ func (se *SQLExecutor) Query(name, statement string) (map[string][]interface{}, 
 		}
 
 		for i, val := range vals {
-			table[cols[i]] = append(table[cols[i]], val)
+			columnName := strings.ToLower(cols[i])
+			table[columnName] = append(table[columnName], val)
 		}
 		cnt++
 	} // end of row.Next()

--- a/dbi/mock/mockData.go
+++ b/dbi/mock/mockData.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package mockdata
 
-import "github.com/intelsdi-x/snap/control/plugin"
+import (
+	"time"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+)
 
 var (
 
@@ -51,8 +55,14 @@ var (
 
 	// QueryOutput is a mocked query output
 	QueryOutput = map[string][]interface{}{
-		"category": []interface{}{"categoryA", "categoryB", "categoryC"},
+		"category": []interface{}{[]byte(`categoryA`), []byte(`categoryB`), "categoryC"},
 		"value":    []interface{}{-10.5, 0.0, 10.5},
+	}
+
+	// QueryOutputTimestamp is a mocked query output, where values are timestamps
+	QueryOutputTimestamp = map[string][]interface{}{
+		"category": []interface{}{[]byte(`categoryA`), []byte(`categoryB`), "categoryC"},
+		"value":    []interface{}{time.Now(), time.Now().Add(1 * time.Hour), time.Now().Add(2 * time.Hour)},
 	}
 
 	// FileName is a path of mock setfile

--- a/dbi/parser/parser.go
+++ b/dbi/parser/parser.go
@@ -51,13 +51,13 @@ func GetDBItemsFromConfig(fName string) (map[string]*dtype.Database, map[string]
 	}
 
 	if len(data) == 0 {
-		return nil, nil, fmt.Errorf("SQL settings file `%s` is empty", fName)
+		return nil, nil, fmt.Errorf("SQL settings file `%v` is empty", fName)
 	}
 
 	err = json.Unmarshal(data, &sqlCnf)
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("Invalid structure of file `%s` to be unmarshalled", fName)
+		return nil, nil, fmt.Errorf("Invalid structure of file `%v` to be unmarshalled", fName)
 	}
 
 	p := &Parser{


### PR DESCRIPTION
This pull request resolves issues: #2 and #5 (common solution), and #4
### 1) Adding to metric namespace values from column defined by "instance_from" other than string only, related to #2
#### Before changes:

when we would like to put as `instance_from="id"` where "id" column is a serial type (not string as expected), metrics namespaces were corrupted: 

```
$ snapctl metric list
NAMESPACE                                VERSIONS
/intel/dbi/meteo/hum/%!s_int64=1_        1
/intel/dbi/meteo/hum/%!s_int64=2_        1
/intel/dbi/meteo/hum/%!s_int64=3_        1
/intel/dbi/meteo/temp/%!s_int64=1_       1
/intel/dbi/meteo/temp/%!s_int64=2_       1
/intel/dbi/meteo/temp/%!s_int64=3_       1
```
#### After changes:

Value form column defined by "instance_from" can be of others type, for example int

```
$ snapctl metric list
NAMESPACE                                VERSIONS
/intel/dbi/meteo/hum/1                   1
/intel/dbi/meteo/hum/2                   1
/intel/dbi/meteo/hum/3                   1
/intel/dbi/meteo/temp/1                  1
/intel/dbi/meteo/temp/2                  1
/intel/dbi/meteo/temp/3                  1
```
### 2) Converting []byte to string to getting a string/text value of metric as expected, related to #5

A text data obtain from database are represented as an array of bytes, and conversion it to string is needed, i.a for  proper interpretation these values by influxdb publisher.
### 3) Unified names of columns to lower letter and then matching results, related to #4
#### Before changes:

Let's assume that database contains some table with two columns `StationId`, `Temperature`.

For postgresql, "select *" query from this table gives as results output table with column `stationid`, `temperature` and these names will be considered by plugin to match value, so in setfile user has to put:

``` json
{
  "instance_from": "stationid",
   "value_from": "temperature"
}
```

What is the problem is that user could have a doubt about that and try to define this fields as origin names of columns containing capital letters (and will get an error)
#### After changes:

Both ways are correct:

``` json
{
  "instance_from": "stationid",
   "value_from": "temperature"
}
```

or

``` json
{
  "instance_from": "StationId",
   "value_from": "Temperature"
}
```
